### PR TITLE
Added access to hardware serial object, for binary communication

### DIFF
--- a/include/jevois/Core/Engine.H
+++ b/include/jevois/Core/Engine.H
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <jevois/Core/VideoMapping.H>
+#include <jevois/Core/Serial.H>
 #include <jevois/Component/Manager.H>
 #include <jevois/Types/Enum.H>
 #include <jevois/Image/RawImage.H>
@@ -285,6 +286,10 @@ namespace jevois
       /*! \note When islog is true, this is assumes to be a log message, and it will be sent to the port(s) specified by
           parameter serlog. Otherwise, the message will be sent to the ports specified by parameter serout. */
       void sendSerial(std::string const & str, bool islog = false);
+      
+      //! Retrieve a pointer to the hardware serial interface
+      /*! \note  Returns nullptr if none is available */
+      Serial* getHardwareSerial();
 
     protected:
       //! Run a script from file

--- a/include/jevois/Core/Module.H
+++ b/include/jevois/Core/Module.H
@@ -345,6 +345,10 @@ namespace jevois
       /*! The format here is free. Just use std::endl to demarcate lines, these will be converted to the appropriate
           line endings by the serial ports. Default implementation writes "None" to os. */
       virtual void supportedCommands(std::ostream & os);
+      
+      //! Get the parent engine.
+      /*! Should not be called in the module constructor, but at the init functions (e.g. postInit) */
+      Engine* getEngine();
   };
 
   namespace module

--- a/src/jevois/Core/Engine.C
+++ b/src/jevois/Core/Engine.C
@@ -851,6 +851,16 @@ void jevois::Engine::sendSerial(std::string const & str, bool islog)
   }
 }
 
+jevois::Serial* jevois::Engine::getHardwareSerial()
+{
+  for (auto & s : itsSerials)
+  {
+    if (s->type() == jevois::UserInterface::Type::Hard)
+      return static_cast<jevois::Serial*>(s.get());
+  }
+  return nullptr;
+}
+
 // ####################################################################################################
 jevois::VideoMapping const & jevois::Engine::getCurrentVideoMapping() const
 {

--- a/src/jevois/Core/Module.C
+++ b/src/jevois/Core/Module.C
@@ -213,6 +213,13 @@ void jevois::Module::supportedCommands(std::ostream & os)
 { os << "None" << std::endl; }
 
 // ####################################################################################################
+jevois::Engine* jevois::Module::getEngine()
+{
+  if (!itsParent) return nullptr;
+  return dynamic_cast<jevois::Engine *>(itsParent);
+}
+
+// ####################################################################################################
 // ####################################################################################################
 jevois::StdModule::StdModule(std::string const & instance) :
     jevois::Module(instance)


### PR DESCRIPTION
When working on a vision module, I wanted to send binary data over the hardware serial.  There is no interface to get the jevois::Serial object, and sometimes the text based sendSerial methods won't do.

To remedy, and give the ability for full control to a module, I added two changes:
1.  Engine::getHardwareSerial   to return the jevois::Serial object
2.  Module::getEngine  to give a module access to the engine in order to use the above.

This change was tested on the hardware and works well.